### PR TITLE
Feature/get trunk vlans

### DIFF
--- a/build/lib/pyhpeimc/objects.py
+++ b/build/lib/pyhpeimc/objects.py
@@ -108,7 +108,7 @@ class IMCInterface:
         self.mtu = get_interface_details(self.devid, ifIndex,auth, url)['mtu']
         self.speed = get_interface_details(self.devid, ifIndex,auth, url)['ifspeed']
         self.accessinterfaces = get_device_access_interfaces(self.devid,auth, url)
-        self.pvid = get_access_interface_vlan(self.ifIndex, self.accessinterfaces,auth, url)
+        self.pvid = get_interface_vlans(self.ifIndex, self.accessinterfaces, auth, url)
         self.auth = auth
         self.url = url
 

--- a/build/lib/pyhpeimc/plat/vlanm.py
+++ b/build/lib/pyhpeimc/plat/vlanm.py
@@ -188,7 +188,7 @@ def get_access_interface_vlan(ifIndex, accessinterfacelist, auth, url):
 
     >>> access_interface_list = get_device_access_interfaces('10', auth.creds, auth.url)
 
-    >>> get_access_interface_vlan('4', access_interface_list, auth.creds, auth.url)
+    >>> get_interface_vlans('4', access_interface_list, auth.creds, auth.url)
     '1'
     """
     for i in accessinterfacelist:

--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -173,7 +173,10 @@ class IMCInterface:
         self.trunkinterfaces = get_trunk_interfaces(self.auth, self.url, devip=self.ip)
         self.interfaces = self.accessinterfaces + self.trunkinterfaces
         self.pvid = get_interface_vlans(self.ifIndex, self.interfaces)['pvid']
-        self.allowedvlans = get_interface_vlans(self.ifIndex, self.interfaces)['allowedVlans']
+        try:
+            self.allowedvlans = get_interface_vlans(self.ifIndex, self.interfaces)['allowedVlans']
+        except KeyError:
+            self.allowedvlans = {}
 
     def getpvid(self):
         """
@@ -187,7 +190,12 @@ class IMCInterface:
         Function operates on the IMCInterface object and updates the pvid attribute
         :return:
         """
-        self.allowedvlans = get_interface_vlans(self.ifIndex, self.interfaces)['allowedVlans']
+        try:
+            self.allowedvlans = get_interface_vlans(self.ifIndex, self.interfaces)['allowedVlans']
+        except KeyError:
+            self.allowedvlans = {}
+
+    # TODO: add method to set PVID and allowedVlans
 
 
 # TODO refactor deallocateIp method for human consumption

--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -177,22 +177,6 @@ class IMCInterface:
         self.pvid = self.interfacevlans['pvid']
         self.allowedvlans = self.interfacevlans['allowedVlans']
 
-    def getpvid(self):
-        """
-        Function operates on the IMCInterface object and updates the pvid attribute
-        :return:
-        """
-        self.interfacevlans = get_interface_vlans(self.ifIndex, self.interfaces)
-        self.pvid = self.interfacevlans['pvid']
-
-    def getallowedvlans(self):
-        """
-        Function operates on the IMCInterface object and updates the pvid attribute
-        :return:
-        """
-        self.interfacevlans = get_interface_vlans(self.ifIndex, self.interfaces)
-        self.allowedvlans = self.interfacevlans['allowedVlans']
-
     # TODO: add method to set PVID and allowedVlans
 
 

--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -158,23 +158,24 @@ class IMCInterface:
         self.url = url
         self.ip = get_dev_details(ip_address, self.auth, self.url)['ip']
         self.devid = get_dev_details(ip_address, self.auth, self.url)['id']
-        self.ifIndex = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)['ifIndex']
-        self.macaddress = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)[
+        self.ifIndex = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)['ifIndex']
+        self.macaddress = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)[
             'phyAddress']
-        self.status = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)['statusDesc']
-        self.adminstatus = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)[
+        self.status = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)['statusDesc']
+        self.adminstatus = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)[
             'adminStatusDesc']
-        self.name = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)['ifDescription']
-        self.description = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)[
+        self.name = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)['ifDescription']
+        self.description = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)[
             'ifAlias']
-        self.mtu = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)['mtu']
-        self.speed = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)['ifspeed']
-        self.accessinterfaces = get_device_access_interfaces(self.auth, self.url, devip = self.ip)
+        self.mtu = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)['mtu']
+        self.speed = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)['ifspeed']
+        self.accessinterfaces = get_device_access_interfaces(self.auth, self.url, devip=self.ip)
         self.trunkinterfaces = get_trunk_interfaces(self.auth, self.url, devip=self.ip)
         self.interfaces = self.accessinterfaces + self.trunkinterfaces
-        self.pvid = get_interface_vlans(self.ifIndex, self.interfaces)['pvid']
+        self.interfacevlans = get_interface_vlans(self.ifIndex, self.interfaces)
+        self.pvid = self.interfacevlans['pvid']
         try:
-            self.allowedvlans = get_interface_vlans(self.ifIndex, self.interfaces)['allowedVlans']
+            self.allowedvlans = self.interfacevlans['allowedVlans']
         except KeyError:
             self.allowedvlans = {}
 

--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -173,28 +173,25 @@ class IMCInterface:
         self.trunkinterfaces = get_trunk_interfaces(self.auth, self.url, devip=self.ip)
         self.interfaces = self.accessinterfaces + self.trunkinterfaces
         self.interfacevlans = get_interface_vlans(self.ifIndex, self.interfaces)
+        self.ifType = self.interfacevlans['ifType']
         self.pvid = self.interfacevlans['pvid']
-        try:
-            self.allowedvlans = self.interfacevlans['allowedVlans']
-        except KeyError:
-            self.allowedvlans = {}
+        self.allowedvlans = self.interfacevlans['allowedVlans']
 
     def getpvid(self):
         """
         Function operates on the IMCInterface object and updates the pvid attribute
         :return:
         """
-        self.pvid = get_interface_vlans(self.ifIndex, self.interfaces)['pvid']
+        self.interfacevlans = get_interface_vlans(self.ifIndex, self.interfaces)
+        self.pvid = self.interfacevlans['pvid']
 
     def getallowedvlans(self):
         """
         Function operates on the IMCInterface object and updates the pvid attribute
         :return:
         """
-        try:
-            self.allowedvlans = get_interface_vlans(self.ifIndex, self.interfaces)['allowedVlans']
-        except KeyError:
-            self.allowedvlans = {}
+        self.interfacevlans = get_interface_vlans(self.ifIndex, self.interfaces)
+        self.allowedvlans = self.interfacevlans['allowedVlans']
 
     # TODO: add method to set PVID and allowedVlans
 

--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -170,7 +170,10 @@ class IMCInterface:
         self.mtu = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)['mtu']
         self.speed = get_interface_details(ifindex, self.auth, self.url, devip= self.ip)['ifspeed']
         self.accessinterfaces = get_device_access_interfaces(self.auth, self.url, devip = self.ip)
-        self.pvid = get_access_interface_vlan(self.ifIndex, self.accessinterfaces)
+        self.trunkinterfaces = get_trunk_interfaces(self.auth, self.url, devip=self.ip)
+        self.interfaces = self.accessinterfaces + self.trunkinterfaces
+        self.pvid = get_interface_vlans(self.ifIndex, self.interfaces)['pvid']
+        self.allowedvlans = get_interface_vlans(self.ifIndex, self.interfaces)['allowedVlans']
 
 
 # TODO refactor deallocateIp method for human consumption

--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -175,6 +175,20 @@ class IMCInterface:
         self.pvid = get_interface_vlans(self.ifIndex, self.interfaces)['pvid']
         self.allowedvlans = get_interface_vlans(self.ifIndex, self.interfaces)['allowedVlans']
 
+    def getpvid(self):
+        """
+        Function operates on the IMCInterface object and updates the pvid attribute
+        :return:
+        """
+        self.pvid = get_interface_vlans(self.ifIndex, self.interfaces)['pvid']
+
+    def getallowedvlans(self):
+        """
+        Function operates on the IMCInterface object and updates the pvid attribute
+        :return:
+        """
+        self.allowedvlans = get_interface_vlans(self.ifIndex, self.interfaces)['allowedVlans']
+
 
 # TODO refactor deallocateIp method for human consumption
 # TODO Add real_time_locate functionality to nextfreeip method to search IP address before offering

--- a/pyhpeimc/plat/vlanm.py
+++ b/pyhpeimc/plat/vlanm.py
@@ -446,7 +446,13 @@ def get_interface_vlans(ifindex, interfacelist):
     for i in interfacelist:
         if i['ifIndex'] == ifindex:
             # TODO: fix response from IMC where allowedVlans contains a range of VLAN IDs, convert to full list
-            result = i
+            if 'allowedVlans' in i.keys():
+                i['ifType'] = 'trunk'
+                result = i
+            else:
+                i['allowedVlans'] = ''
+                i['ifType'] = 'access'
+                result = i
     return result
 
 

--- a/pyhpeimc/plat/vlanm.py
+++ b/pyhpeimc/plat/vlanm.py
@@ -415,7 +415,7 @@ def set_access_interface_pvid(ifindex, pvid, auth, url, devip=None, devid=None):
         return "Error:\n" + str(error) + " set_access_interface_pvid: An Error has occured"
 
 
-def get_access_interface_vlan(ifindex, accessinterfacelist):
+def get_interface_vlans(ifindex, interfacelist):
     """
     Function which takes input of str of ifIndex value for target interface and
     accessinterfacelist ( output of get_device_access_interfaces) to send against IMC REST
@@ -439,14 +439,15 @@ def get_access_interface_vlan(ifindex, accessinterfacelist):
     >>> access_interface_list = get_device_access_interfaces(auth.creds, auth.url,
                                                              devip='10.101.0.221')
 
-    >>> get_access_interface_vlan('4', access_interface_list, auth.creds, auth.url)
+    >>> get_interface_vlans('4', access_interface_list, auth.creds, auth.url)
     '1'
     """
-    for i in accessinterfacelist:
+    result = None
+    for i in interfacelist:
         if i['ifIndex'] == ifindex:
-            return i['pvid']
-        else:
-            return "Not an Access Port"
+            # TODO: fix response from IMC where allowedVlans contains a range of VLAN IDs, convert to full list
+            result = i
+    return result
 
 
 def create_dev_vlan(vlanid, vlan_name, auth, url, devid=None, devip=None):


### PR DESCRIPTION
Updated the process for **getting the PVID for an interface** to make it work for both access and trunk interfaces, to abstract this concept from users of the API client. An interface PVID should be retrieved or set in the same manner, regardless of whether the interface is access or trunk, the client can handle this difference internally by storing the interface type in a class instance attribute.

This change updates **IMCInterface** with additional attributes, as follows:
- self.interfaces: combines self.accessinterfaces and self.trunkinterfaces into a single attribute
- self.interfacevlans: now passes the new self.interfaces attribute to the function that parses out the PVIDs (get_interface_vlans - also updated, see below)
- self.ifType: retrieves and stores the interface type (access or trunk)
- self.pvid: now derives the pvid from the pvid attribute on self.interfacevlans
- self.allowedvlans: derives the list of allowed VLANs from the allowedVlans attribute on self.interfacevlans
(the above 3 attributes all derive their data from self.interfacevlans, rather than firing off a separate API call for each attribute to the same API endpoint, data is retrieved once and distributed. Hopefully this doesn't break anything else)

**plat/vlanm.py get_interface_vlans()** is also updated, as follows:
- now returns a dictionary of interface vlan attributes, including pvid, ifType, and allowedVlans, or None otherwise
- if allowedVlans is not present (e.g. on access interfaces), an empty allowedVlans attribute is added so that API client users can simply test for the presence of allowed vlans
- ifType is set to 'access' or 'trunk' depending on the presence of allowedVlans in the response from IMC. This is passed back in the return object so that users, like the IMCInterface class, can act upon the interface in the appropriate manner.

