### PR TITLE
Feature/set pvid

### DIFF
--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -103,8 +103,8 @@ class IMCDev:
         self.assets = get_dev_asset_details(self.ip, auth, url)
         self.serials = [({'name': asset['name'], 'serialNum': asset['serialNum']}) for asset in
                          self.assets]
-        self.runconfig = get_dev_run_config(auth, url, devip = self.ip)
-        self.startconfig = get_dev_start_config(auth, url, devip = self.ip)
+        # self.runconfig = get_dev_run_config(auth, url, devip = self.ip)
+        # self.startconfig = get_dev_start_config(auth, url, devip = self.ip)
         self.ipmacarp = get_ip_mac_arp_list(auth, url, devip = self.ip)
 
     def getvlans(self):
@@ -174,7 +174,7 @@ class IMCInterface:
         self.interfaces = self.accessinterfaces + self.trunkinterfaces
         self.interfacevlans = get_interface_vlans(self.ifIndex, self.interfaces)
         self.ifType = self.interfacevlans['ifType']
-        self.pvid = self.interfacevlans['pvid']
+        self._pvid = self.interfacevlans['pvid']
         self.allowedvlans = self.interfacevlans['allowedVlans']
 
     @property
@@ -185,9 +185,11 @@ class IMCInterface:
     def pvid(self, vlan):
         if int(vlan) < 1 or int(vlan) > 4096:
             raise ValueError("VLAN ID must be between 1 and 4096")
-        update_int = set_interface_pvid(self.ifIndex, self.ifType, vlan, self.auth, self.url, self.ip)
+        update_int = set_interface_pvid(self.ifIndex, self.ifType, vlan, self.auth, self.url, self.ip,
+                                        allowedVlans=self.allowedvlans)
         print('Response: ' + str(update_int))  # + ', current PVID: ' + self.pvid + ', new PVID: ' + vlan)
         if update_int == 204:
+            # TODO: this isn't very robust, it doesn't confirm that the PVID has actually been updated
             self._pvid = vlan
         else:
             raise ValueError("Unable to set PVID - check VLAN exists on switch")

--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -85,6 +85,7 @@ class IMCDev:
         """
         self.auth = auth
         self.url = url
+        # TODO: needs to throw a useful error when a non-existant switch IP is provided
         self.ip = get_dev_details(ip_address, auth, url)['ip']
         self.description = get_dev_details(ip_address, auth, url)['sysDescription']
         self.location = get_dev_details(ip_address, auth, url)['location']
@@ -158,6 +159,7 @@ class IMCInterface(object):
         self.url = url
         self.ip = get_dev_details(ip_address, self.auth, self.url)['ip']
         self.devid = get_dev_details(ip_address, self.auth, self.url)['id']
+        # TODO: needs to throw a useful error when a non-existant ifIndex is provided
         self.ifIndex = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)['ifIndex']
         self.macaddress = get_interface_details(ifindex, self.auth, self.url, devip=self.ip)[
             'phyAddress']

--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -97,15 +97,15 @@ class IMCDev:
         self.numinterface = len(get_all_interface_details(auth, url, devip=self.ip))
         self.vlans = get_dev_vlans(auth, url, devid=None, devip=self.ip)
         self.accessinterfaces = get_device_access_interfaces(auth, url, devip=self.ip)
-        self.trunkinterfaces = get_trunk_interfaces(auth, url, devip = self.ip)
-        self.alarm = get_dev_alarms(auth, url, devip = self.ip)
-        self.numalarm = len(get_dev_alarms(auth, url, devip= self.ip))
+        self.trunkinterfaces = get_trunk_interfaces(auth, url, devip=self.ip)
+        self.alarm = get_dev_alarms(auth, url, devip=self.ip)
+        self.numalarm = len(get_dev_alarms(auth, url, devip=self.ip))
         self.assets = get_dev_asset_details(self.ip, auth, url)
         self.serials = [({'name': asset['name'], 'serialNum': asset['serialNum']}) for asset in
                          self.assets]
-        # self.runconfig = get_dev_run_config(auth, url, devip = self.ip)
-        # self.startconfig = get_dev_start_config(auth, url, devip = self.ip)
-        self.ipmacarp = get_ip_mac_arp_list(auth, url, devip = self.ip)
+        self.runconfig = get_dev_run_config(auth, url, devip=self.ip) if 'HP 3800' not in self.type else None
+        self.startconfig = get_dev_start_config(auth, url, devip=self.ip) if 'HP 3800' not in self.type else None
+        self.ipmacarp = get_ip_mac_arp_list(auth, url, devip=self.ip)
 
     def getvlans(self):
         """
@@ -200,7 +200,7 @@ class IMCInterface(object):
                 raise ValueError("Error setting PVID - the PVID did not change as required")
         else:
             raise ValueError("Unable to set PVID - check VLAN exists on switch")
-    # TODO: add property and setter for allowedVlans
+    # TODO: add property and setter for allowedVlans - requires allowedVlans to be a proper list
 
 # TODO refactor deallocateIp method for human consumption
 # TODO Add real_time_locate functionality to nextfreeip method to search IP address before offering

--- a/pyhpeimc/objects.py
+++ b/pyhpeimc/objects.py
@@ -177,7 +177,20 @@ class IMCInterface:
         self.pvid = self.interfacevlans['pvid']
         self.allowedvlans = self.interfacevlans['allowedVlans']
 
-    # TODO: add method to set PVID and allowedVlans
+    @property
+    def pvid(self):
+        return self._pvid
+
+    @pvid.setter
+    def pvid(self, vlan):
+        if int(vlan) < 1 or int(vlan) > 4096:
+            raise ValueError("VLAN ID must be between 1 and 4096")
+        update_int = set_interface_pvid(self.ifIndex, self.ifType, vlan, self.auth, self.url, self.ip)
+        print('Response: ' + str(update_int))  # + ', current PVID: ' + self.pvid + ', new PVID: ' + vlan)
+        if update_int == 204:
+            self._pvid = vlan
+        else:
+            raise ValueError("Unable to set PVID - check VLAN exists on switch")
 
 
 # TODO refactor deallocateIp method for human consumption

--- a/pyhpeimc/plat/vlanm.py
+++ b/pyhpeimc/plat/vlanm.py
@@ -448,12 +448,10 @@ def get_interface_vlans(ifindex, interfacelist):
             # TODO: fix response from IMC where allowedVlans contains a range of VLAN IDs, convert to full list
             if 'allowedVlans' in i.keys():
                 i['ifType'] = 'trunk'
-                print('get_interface_vlans returning a trunk interface')
                 result = i
             else:
                 i['allowedVlans'] = ''
                 i['ifType'] = 'access'
-                print('get_interface_vlans returning an access interface')
                 result = i
     return result
 
@@ -505,18 +503,15 @@ def set_interface_pvid(ifindex, ifType, pvid, auth, url, devip=None, devid=None,
         set_interface_pvid_url = "/imcrs/vlan/access?devId=" + devid + "&destVlanId=" + pvid \
                                         + "&ifIndex=" + str(ifindex)
         f_url = url + set_interface_pvid_url
-        print('Setting access interface')
         response = requests.put(f_url, auth=auth, headers=HEADERS)
     elif ifType == 'trunk':
         set_interface_pvid_url = "/imcrs/vlan/trunk?devId=" + devid
         f_url = url + set_interface_pvid_url
-        # TODO: payload needs to include allowedVlans?
         if allowedVlans is not None:
             payload = '''{"ifIndex": "''' + str(ifindex) + '''", "pvid": "''' + pvid + '''", 
             "allowedVlans": "''' + allowedVlans + '''"}'''
         else:
             payload = '''{"ifIndex": "''' + str(ifindex) + '''", "pvid": "''' + pvid + '''"}'''
-        print('Setting trunk interface')
         response = requests.put(f_url, data=payload, auth=auth, headers=HEADERS)
     else:
         raise ValueError('Incorrect ifType: \'%s\'. Must be either \'access\' or \'trunk\'' % ifType)


### PR DESCRIPTION
Updated the IMCInterface object with a pvid property setter, and a function to re-get the interface and vlans details to update the object after a change is made.

Also fixed an issue with IMCDev - runconfig and startconfig don't seem to be supported by HP 3800 switches via IMC and when an IMCDev instance is created against this type of switch it takes a long time. Added a check for 'HP 3800' switch type to avoid this.
